### PR TITLE
[WW-3755] Fix typo in alignment label

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -70,7 +70,7 @@ export const textOptions = {
         },
         label: {
             en: 'Alignment',
-            fr: 'Alignment',
+            fr: 'Alignement',
         },
         responsive: true,
         bindable: true,

--- a/src/settings.js
+++ b/src/settings.js
@@ -69,8 +69,8 @@ export const textOptions = {
             ],
         },
         label: {
-            en: 'Alignement',
-            fr: 'Alignement',
+            en: 'Alignment',
+            fr: 'Alignment',
         },
         responsive: true,
         bindable: true,


### PR DESCRIPTION
## Summary
• Fixed typo in French alignment label from 'Alignement' to 'Alignment' in textOptions configuration
• Corrected consistency between English and French labels in settings.js

## Test plan
- [ ] Verify that the alignment setting displays correctly in the UI
- [ ] Check that the fix doesn't break any existing functionality
- [ ] Test on both English and French language settings