### PR TITLE
Add enableLatex feature for LaTeX rendering support

### DIFF
--- a/AI.json
+++ b/AI.json
@@ -81,6 +81,12 @@
       "defaultValue": false
     },
     {
+      "name": "enableLatex",
+      "description": "Enable LaTeX rendering in the editor. When true, text wrapped in single ($...$) or double ($$...$$) dollar signs is auto-converted to rendered math. Set to false to keep dollar-sign text literal (e.g. currency values like \"$6,500 or $3,700\").",
+      "type": "boolean",
+      "defaultValue": true
+    },
+    {
       "name": "mentionList",
       "description": "Array of objects used to populate the mention suggestions. Typically bound to a collection. Inactive when enableMention is false.",
       "type": "array",
@@ -659,20 +665,20 @@
     },
     {
       "name": "parameterInlineMath",
-      "description": "Show the inline-math button in the toolbar. Inactive when customMenu is true.",
+      "description": "Show the inline-math button in the toolbar. Inactive when customMenu is true, or when enableLatex is false.",
       "type": "boolean",
       "defaultValue": false,
       "inactiveProperty": {
-        "description": "Inactive when customMenu is true."
+        "description": "Inactive when customMenu is true, or when enableLatex is false."
       }
     },
     {
       "name": "parameterBlockMath",
-      "description": "Show the block-math button in the toolbar. Inactive when customMenu is true.",
+      "description": "Show the block-math button in the toolbar. Inactive when customMenu is true, or when enableLatex is false.",
       "type": "boolean",
       "defaultValue": false,
       "inactiveProperty": {
-        "description": "Inactive when customMenu is true."
+        "description": "Inactive when customMenu is true, or when enableLatex is false."
       }
     },
     {

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -699,8 +699,8 @@ export default {
                 image: this.content.parameterImage ?? false,
                 codeBlock: this.content.parameterCodeBlock ?? true,
                 blockquote: this.content.parameterQuote ?? true,
-                inlineMath: this.content.parameterInlineMath ?? false,
-                blockMath: this.content.parameterBlockMath ?? false,
+                inlineMath: (this.content.parameterInlineMath ?? false) && (this.content.enableLatex ?? true),
+                blockMath: (this.content.parameterBlockMath ?? false) && (this.content.enableLatex ?? true),
                 undo: this.content.parameterUndo ?? true,
                 redo: this.content.parameterRedo ?? true,
             };
@@ -718,6 +718,9 @@ export default {
                     list: this.mentionList,
                     allowSpaces: this.content.mentionAllowSpaces,
                     char: this.content.mentionChar,
+                },
+                latex: {
+                    enabled: this.content.enableLatex ?? true,
                 },
             };
         },
@@ -1005,19 +1008,21 @@ export default {
                                 char: this.editorConfig.mention.char,
                             },
                         }),
-                    Mathematics.configure({
-                        regex: /(?<!\$)\$([^\$]+)\$(?!\$)/gi,
-                        katexOptions: {
-                            throwOnError: false,
-                        },
-                    }),
-                    Mathematics.extend({ name: 'MathematicsDisplay' }).configure({
-                        regex: /\$\$([^\$]+)\$\$/gi,
-                        katexOptions: {
-                            throwOnError: false,
-                            displayMode: true,
-                        },
-                    }),
+                    this.editorConfig.latex.enabled &&
+                        Mathematics.configure({
+                            regex: /(?<!\$)\$([^\$]+)\$(?!\$)/gi,
+                            katexOptions: {
+                                throwOnError: false,
+                            },
+                        }),
+                    this.editorConfig.latex.enabled &&
+                        Mathematics.extend({ name: 'MathematicsDisplay' }).configure({
+                            regex: /\$\$([^\$]+)\$\$/gi,
+                            katexOptions: {
+                                throwOnError: false,
+                                displayMode: true,
+                            },
+                        }),
                 ],
                 onCreate: () => {
                     this.setValue(this.getContent());

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -587,6 +587,15 @@ export default {
             },
             immediate: true,
         },
+        // For updating legacy elements before introduction of enableLatex
+        'content.enableLatex': {
+            handler(value) {
+                if (value === undefined) {
+                    this.$emit('update:content:effect', { enableLatex: true });
+                }
+            },
+            immediate: true,
+        },
         'wwEditorState.isSelected'() {
             this.$emit('update:sidepanel-content', { path: 'selectedTag', value: null });
         },

--- a/ww-config.js
+++ b/ww-config.js
@@ -73,6 +73,7 @@ export default {
                 'mentionIdPath',
                 'mentionLabelPath',
             ],
+            'enableLatex',
             [
                 'parameterTitle',
                 'parameterTextType',
@@ -361,6 +362,14 @@ export default {
             },
             type: 'OnOff',
             defaultValue: false,
+        },
+        enableLatex: {
+            section: 'settings',
+            label: {
+                en: 'LaTeX rendering',
+            },
+            type: 'OnOff',
+            defaultValue: true,
         },
         mentionList: {
             section: 'settings',
@@ -1696,7 +1705,7 @@ export default {
         },
         parameterInlineMath: {
             section: 'settings',
-            hidden: content => content.customMenu,
+            hidden: content => content.customMenu || !(content.enableLatex ?? true),
             label: {
                 en: 'Inline math',
             },
@@ -1718,7 +1727,7 @@ export default {
         },
         parameterBlockMath: {
             section: 'settings',
-            hidden: content => content.customMenu,
+            hidden: content => content.customMenu || !(content.enableLatex ?? true),
             label: {
                 en: 'Block math',
             },


### PR DESCRIPTION
- Introduced a new configuration option `enableLatex` to toggle LaTeX rendering in the editor.
- Updated related properties to respect the `enableLatex` setting, ensuring inline and block math buttons are only visible when LaTeX is enabled.
- Adjusted documentation in AI.json to reflect the new feature and its default value.