### PR TITLE
[WW-5274] Vulnerability fix for BNP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@tiptap/extension-color": "2.8.0",
                 "@tiptap/extension-image": "2.8.0",
-                "@tiptap/extension-link": "2.8.0",
+                "@tiptap/extension-link": "2.10.4",
                 "@tiptap/extension-mathematics": "2.26.1",
                 "@tiptap/extension-mention": "2.8.0",
                 "@tiptap/extension-placeholder": "2.8.0",
@@ -209,6 +209,7 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
             "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -218,6 +219,7 @@
             "version": "7.25.9",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
             "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -345,6 +347,7 @@
             "version": "7.26.2",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
             "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.26.0"
@@ -500,6 +503,7 @@
             "version": "7.26.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
             "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.25.9",
@@ -650,6 +654,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
@@ -977,9 +982,9 @@
             }
         },
         "node_modules/@tiptap/extension-link": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.8.0.tgz",
-            "integrity": "sha512-p67hCG/pYCiOK/oCTPZnlkw9Ei7KJ7kCKFaluTcAmr5j8IBdYfDqSMDNCT4vGXBvKFh4X6xD7S7QvOqcH0Gn9A==",
+            "version": "2.10.4",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.10.4.tgz",
+            "integrity": "sha512-9lbtMUPc9IYCRMKV/B4k/no9J5OQQl/jJn9W2ce3NjJZSrOjuZs0CjJZgCESIaj6911s7nEJUvxKKmsbD3UC3Q==",
             "license": "MIT",
             "dependencies": {
                 "linkifyjs": "^4.1.0"
@@ -1761,118 +1766,6 @@
                 "eslint-plugin-prettier": "^3.1.0",
                 "prettier": ">= 1.13.0"
             }
-        },
-        "node_modules/@vue/reactivity": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.12.tgz",
-            "integrity": "sha512-UzaN3Da7xnJXdz4Okb/BGbAaomRHc3RdoWqTzlvd9+WBR5m3J39J1fGcHes7U3za0ruYn/iYy/a1euhMEHvTAg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/shared": "3.5.12"
-            }
-        },
-        "node_modules/@vue/reactivity/node_modules/@vue/shared": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.12.tgz",
-            "integrity": "sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@vue/runtime-core": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.12.tgz",
-            "integrity": "sha512-hrMUYV6tpocr3TL3Ad8DqxOdpDe4zuQY4HPY3X/VRh+L2myQO8MFXPAMarIOSGNu0bFAjh1yBkMPXZBqCk62Uw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/reactivity": "3.5.12",
-                "@vue/shared": "3.5.12"
-            }
-        },
-        "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.12.tgz",
-            "integrity": "sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@vue/runtime-dom": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.12.tgz",
-            "integrity": "sha512-q8VFxR9A2MRfBr6/55Q3umyoN7ya836FzRXajPB6/Vvuv0zOPL+qltd9rIMzG/DbRLAIlREmnLsplEF/kotXKA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/reactivity": "3.5.12",
-                "@vue/runtime-core": "3.5.12",
-                "@vue/shared": "3.5.12",
-                "csstype": "^3.1.3"
-            }
-        },
-        "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.12.tgz",
-            "integrity": "sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/@vue/server-renderer": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.12.tgz",
-            "integrity": "sha512-I3QoeDDeEPZm8yR28JtY+rk880Oqmj43hreIBVTicisFTx/Dl7JpG72g/X7YF8hnQD3IFhkky5i2bPonwrTVPg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.12",
-                "@vue/shared": "3.5.12"
-            },
-            "peerDependencies": {
-                "vue": "3.5.12"
-            }
-        },
-        "node_modules/@vue/server-renderer/node_modules/@vue/compiler-core": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.12.tgz",
-            "integrity": "sha512-ISyBTRMmMYagUxhcpyEH0hpXRd/KqDU4ymofPgl2XAkY9ZhQ+h0ovEZJIiPop13UmR/54oA2cgMDjgroRelaEw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.25.3",
-                "@vue/shared": "3.5.12",
-                "entities": "^4.5.0",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.0"
-            }
-        },
-        "node_modules/@vue/server-renderer/node_modules/@vue/compiler-dom": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.12.tgz",
-            "integrity": "sha512-9G6PbJ03uwxLHKQ3P42cMTi85lDRvGLB2rSGOiQqtXELat6uI4n8cNz9yjfVHRPIu+MsK6TE418Giruvgptckg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/compiler-core": "3.5.12",
-                "@vue/shared": "3.5.12"
-            }
-        },
-        "node_modules/@vue/server-renderer/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.12.tgz",
-            "integrity": "sha512-eLwc7v6bfGBSM7wZOGPmRavSWzNFF6+PdRhE+VFJhNCgHiF8AM7ccoqcv5kBXA2eWUfigD7byekvf/JsOfKvPA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.12",
-                "@vue/shared": "3.5.12"
-            }
-        },
-        "node_modules/@vue/server-renderer/node_modules/@vue/shared": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.12.tgz",
-            "integrity": "sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/@vue/shared": {
             "version": "3.4.22",
@@ -3321,6 +3214,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/debug": {
@@ -4008,6 +3902,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/esutils": {
@@ -5641,6 +5536,7 @@
             "version": "0.30.12",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
             "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -6096,6 +5992,7 @@
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
             "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -6817,6 +6714,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -8218,6 +8116,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -9031,28 +8930,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/vue": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.12.tgz",
-            "integrity": "sha512-CLVZtXtn2ItBIi/zHZ0Sg1Xkb7+PU32bJJ8Bmy7ts3jxXTcbfsEfBivFYYWz1Hur+lalqGAh65Coin0r+HRUfg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.12",
-                "@vue/compiler-sfc": "3.5.12",
-                "@vue/runtime-dom": "3.5.12",
-                "@vue/server-renderer": "3.5.12",
-                "@vue/shared": "3.5.12"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/vue-eslint-parser": {
             "version": "7.11.0",
             "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
@@ -9170,96 +9047,6 @@
             },
             "engines": {
                 "node": ">=4.0.0"
-            }
-        },
-        "node_modules/vue/node_modules/@vue/compiler-core": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.12.tgz",
-            "integrity": "sha512-ISyBTRMmMYagUxhcpyEH0hpXRd/KqDU4ymofPgl2XAkY9ZhQ+h0ovEZJIiPop13UmR/54oA2cgMDjgroRelaEw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.25.3",
-                "@vue/shared": "3.5.12",
-                "entities": "^4.5.0",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.0"
-            }
-        },
-        "node_modules/vue/node_modules/@vue/compiler-dom": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.12.tgz",
-            "integrity": "sha512-9G6PbJ03uwxLHKQ3P42cMTi85lDRvGLB2rSGOiQqtXELat6uI4n8cNz9yjfVHRPIu+MsK6TE418Giruvgptckg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/compiler-core": "3.5.12",
-                "@vue/shared": "3.5.12"
-            }
-        },
-        "node_modules/vue/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.12.tgz",
-            "integrity": "sha512-2k973OGo2JuAa5+ZlekuQJtitI5CgLMOwgl94BzMCsKZCX/xiqzJYzapl4opFogKHqwJk34vfsaKpfEhd1k5nw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.25.3",
-                "@vue/compiler-core": "3.5.12",
-                "@vue/compiler-dom": "3.5.12",
-                "@vue/compiler-ssr": "3.5.12",
-                "@vue/shared": "3.5.12",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.11",
-                "postcss": "^8.4.47",
-                "source-map-js": "^1.2.0"
-            }
-        },
-        "node_modules/vue/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.12.tgz",
-            "integrity": "sha512-eLwc7v6bfGBSM7wZOGPmRavSWzNFF6+PdRhE+VFJhNCgHiF8AM7ccoqcv5kBXA2eWUfigD7byekvf/JsOfKvPA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.12",
-                "@vue/shared": "3.5.12"
-            }
-        },
-        "node_modules/vue/node_modules/@vue/shared": {
-            "version": "3.5.12",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.12.tgz",
-            "integrity": "sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==",
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/vue/node_modules/postcss": {
-            "version": "8.4.47",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-            "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.1.0",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@tiptap/extension-color": "2.8.0",
         "@tiptap/extension-image": "2.8.0",
-        "@tiptap/extension-link": "2.8.0",
+        "@tiptap/extension-link": "2.10.4",
         "@tiptap/extension-mathematics": "2.26.1",
         "@tiptap/extension-mention": "2.8.0",
         "@tiptap/extension-placeholder": "2.8.0",


### PR DESCRIPTION
Related WW-5274 PRs:
- weweb-team/weweb-editor https://github.com/weweb-team/weweb-editor/pull/5247
- weweb-team/weweb-back https://github.com/weweb-team/weweb-back/pull/2030
- weweb-team/weweb-dashboard https://github.com/weweb-team/weweb-dashboard/pull/807
- weweb-team/weweb-lambda-back-publisher https://github.com/weweb-team/weweb-lambda-back-publisher/pull/362
- weweb-team/weweb-plugin-figma https://github.com/weweb-team/weweb-plugin-figma/pull/4
- weweb-team/weweb-cron https://github.com/weweb-team/weweb-cron/pull/73
- weweb-team/weweb-lambda-component-builder https://github.com/weweb-team/weweb-lambda-component-builder/pull/16
- weweb-team/weweb-lambda-publisher https://github.com/weweb-team/weweb-lambda-publisher/pull/167
- weweb-team/weweb-plugins https://github.com/weweb-team/weweb-plugins/pull/507
- weweb-team/weweb-preview https://github.com/weweb-team/weweb-preview/pull/442
- weweb-assets/weweb-server https://github.com/weweb-assets/weweb-server/pull/21
- weweb-assets/ww-input-rich-text https://github.com/weweb-assets/ww-input-rich-text/pull/63
- weweb-assets/ww-slider https://github.com/weweb-assets/ww-slider/pull/24
- weweb-assets/ww-slider-images https://github.com/weweb-assets/ww-slider-images/pull/2
- weweb-assets/plugin-xano https://github.com/weweb-assets/plugin-xano/pull/37
